### PR TITLE
meta-digi-arm: set LAYERDEPENDS to depend on fsl-arm and core

### DIFF
--- a/meta-digi-arm/conf/layer.conf
+++ b/meta-digi-arm/conf/layer.conf
@@ -8,6 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "digi-arm"
 BBFILE_PATTERN_digi-arm := "^${LAYERDIR}/"
 BBFILE_PRIORITY_digi-arm = "5"
+LAYERDEPENDS_digi-arm = "core fsl-arm"
 
 # Digi's General and Open Source license agreements
 DIGI_EULA_FILE = "${LAYERDIR}/DIGI_EULA"


### PR DESCRIPTION
This change allows bitbake to alert users of missing layer dependencies. We also use LAYERDEPENDS to support machines in our Yocto web app.
