### PR TITLE
Update bblayers.conf.sample

### DIFF
--- a/sdk/config/ccimx6ulstarter/bblayers.conf.sample
+++ b/sdk/config/ccimx6ulstarter/bblayers.conf.sample
@@ -13,6 +13,7 @@ BBLAYERS ?= " \
   ##DIGIBASE##/meta-openembedded/meta-python \
   ##DIGIBASE##/meta-openembedded/meta-networking \
   ##DIGIBASE##/meta-openembedded/meta-webserver \
+  ##DIGIBASE##/meta-openembedded/meta-filesystems \
   ##DIGIBASE##/meta-qt5 \
   ##DIGIBASE##/meta-swupdate \
   ##DIGIBASE##/meta-fsl-arm \


### PR DESCRIPTION
meta-openembedded/meta-filesystems layer is missing for ccimx6ulstarter build