### PR TITLE
psplash: always prepend FILESEXTRAPATHS

### DIFF
--- a/meta-digi-dey/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-digi-dey/recipes-core/psplash/psplash_git.bbappend
@@ -1,6 +1,6 @@
 # Copyright (C) 2016 Digi International
 
-FILESEXTRAPATHS_prepend_dey := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://0001-colors-modify-psplash-colors-to-match-Digi-scheme.patch \


### PR DESCRIPTION
Given that we're adding two patch files to SRC_URI regardless of distro/machine, we should therefore always prepend FILESEXTRAPATHS so that these files are always found. Removing '_dey' prevents "Fetcher failure: Unable to find file" if DISTRO is not "dey".