### PR TITLE
Updated syntax for busybox timeout

### DIFF
--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx6qpsbc/standby
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx6qpsbc/standby
@@ -56,7 +56,7 @@ resume_interfaces() {
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d050A"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were bring down on suspend
 		for i in $(echo ${RESUME_IFACES} | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx6qpsbc/standby-actions
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx6qpsbc/standby-actions
@@ -41,7 +41,7 @@ elif [ "${1}" == "post" ]; then
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d050A"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were brought down on suspend
 		for i in $(cat /tmp/suspend_wlan_ifaces | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx6sbc/standby
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx6sbc/standby
@@ -56,7 +56,7 @@ resume_interfaces() {
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d0301"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were bring down on suspend
 		for i in $(echo ${RESUME_IFACES} | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx6sbc/standby-actions
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx6sbc/standby-actions
@@ -41,7 +41,7 @@ elif [ "${1}" == "post" ]; then
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d0301"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were brought down on suspend
 		for i in $(cat /tmp/suspend_wlan_ifaces | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx6ul/standby
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx6ul/standby
@@ -56,7 +56,7 @@ resume_interfaces() {
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d050A"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were bring down on suspend
 		for i in $(echo ${RESUME_IFACES} | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx6ul/standby-actions
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx6ul/standby-actions
@@ -41,7 +41,7 @@ elif [ "${1}" == "post" ]; then
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d050A"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were brought down on suspend
 		for i in $(cat /tmp/suspend_wlan_ifaces | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx8mn/standby
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx8mn/standby
@@ -56,7 +56,7 @@ resume_interfaces() {
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d050A"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were bring down on suspend
 		for i in $(echo ${RESUME_IFACES} | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx8mn/standby-actions
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx8mn/standby-actions
@@ -41,7 +41,7 @@ elif [ "${1}" == "post" ]; then
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=sdio:c00v0271d050A"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were brought down on suspend
 		for i in $(cat /tmp/suspend_wlan_ifaces | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx8x/standby
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx8x/standby
@@ -56,7 +56,7 @@ resume_interfaces() {
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=pci:v0000168Cd0000003Esv*sd*bc*sc*i*"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were bring down on suspend
 		for i in $(echo ${RESUME_IFACES} | tr ' ' '\n' | sort); do

--- a/meta-digi-dey/recipes-core/busybox/busybox/ccimx8x/standby-actions
+++ b/meta-digi-dey/recipes-core/busybox/busybox/ccimx8x/standby-actions
@@ -41,7 +41,7 @@ elif [ "${1}" == "post" ]; then
 	if [ -d "/proc/device-tree/wireless" ]; then
 		# Trigger wireless module loading event, and wait until the interface exists
 		udevadm trigger --action=add --attr-match="modalias=pci:v0000168Cd0000003Esv*sd*bc*sc*i*"
-		timeout -t 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
+		timeout 5 sh -c "while [ ! -d /sys/class/net/wlan0 ]; do sleep .2; done" 2>/dev/null
 
 		# Bring up the interfaces that were brought down on suspend
 		for i in $(cat /tmp/suspend_wlan_ifaces | tr ' ' '\n' | sort); do


### PR DESCRIPTION
A change in busybox ([timeout: fix arguments to match coreutils](https://github.com/mirror/busybox/commit/c9720a761e88e83265b4d75808533cdfbc66075b)) changed the syntax of the timeout command.

The standby scripts in digi-dey need to reflect this change in order to properly wait for wlans to be available. Without this change, the script will silently fall through, sending the error message from timeout to /dev/null