### PR TITLE
Use https protocol for github access

### DIFF
--- a/meta-digi-arm/conf/layer.conf
+++ b/meta-digi-arm/conf/layer.conf
@@ -52,7 +52,7 @@ LICENSE_PATH += "${LAYERDIR}/custom-licenses"
 
 DIGI_MTK_GIT ?= "git://stash.digi.com"
 DIGI_PKG_SRC ?= "https://ftp1.digi.com/support/digiembeddedyocto/source"
-DIGI_GITHUB_GIT ?= "git://github.com/digi-embedded"
+DIGI_GITHUB_GIT ?= "https://github.com/digi-embedded"
 
 # Disable CVE report generation by default
 do_vigiles_check[noexec] = "1"


### PR DESCRIPTION
Unencrypted Git protocol access to github is turned off since 2022, see https://github.blog/2021-09-01-improving-git-protocol-security-github/