### PR TITLE
psplash: fix for distro other than "dey"

### DIFF
--- a/meta-digi-dey/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-digi-dey/recipes-core/psplash/psplash_git.bbappend
@@ -2,11 +2,13 @@
 
 FILESEXTRAPATHS:prepend:dey := "${THISDIR}/files:"
 
-SRC_URI += " \
+SRC_URI:append:dey = " \
     file://0001-colors-modify-psplash-colors-to-match-Digi-scheme.patch \
     file://psplash-digi-bar.png \
 "
 do_patch_png () {
+}
+do_patch_png:dey () {
 	cp ${WORKDIR}/psplash-digi-bar.png ${S}/base-images/psplash-bar.png
 }
 addtask patch_png after do_patch before do_configure


### PR DESCRIPTION
FIXES: if using other DISTRO than dey, patch files are not found

We want to use an own distro conf file (derived from dey) to save our settings outside of local.conf.

This results in errors:

WARNING: /home/klatt/Projekte/yocto/spc.kirkstone/layers/poky/meta/recipes-core/psplash/psplash_git.bb: Unable to get checksum for psplash SRC_URI entry 0001-colors-modify-psplash-colors-to-match-Digi-scheme.patch: file could not be found
WARNING: /home/klatt/Projekte/yocto/spc.kirkstone/layers/poky/meta/recipes-core/psplash/psplash_git.bb: Unable to get checksum for psplash SRC_URI entry psplash-digi-bar.png: file could not be found

ERROR: psplash-0.1+gitAUTOINC+44afb7506d-r0 do_fetch: Fetcher failure: Unable to find file file://0001-colors-modify-psplash-colors-to-match-Digi-scheme.patch anywhere.