### PR TITLE
psplash: fix for distro other than "dey" #2

### DIFF
--- a/meta-digi-dey/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-digi-dey/recipes-core/psplash/psplash_git.bbappend
@@ -11,4 +11,4 @@ do_configure:prepend:dey() {
 	\cp --remove-destination ${WORKDIR}/psplash-digi-bar.png ${S}/base-images/psplash-bar.png
 }
 
-SPLASH_IMAGES = "file://logo.png;outsuffix=default"
+SPLASH_IMAGES:dey = "file://logo.png;outsuffix=default"


### PR DESCRIPTION
see #11

ERROR: psplash-0.1+gitAUTOINC+44afb7506d-r0 do_fetch: Fetcher failure: Unable to find file file://logo.png;outsuffix=default anywhere.